### PR TITLE
Update Node.js

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'The path to the assets you want to upload'
     required: true
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'package'


### PR DESCRIPTION
The action still works with an actual version of runners, but it triggers warning
`The following actions uses node12 which is deprecated and will be forced to run on node16: ./.github/actions/upload-release-assets. For more info:` (https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)
I've checked, it works fine with **node20**, without any warnings